### PR TITLE
Set colors as RGB instead of named values

### DIFF
--- a/dev/standard.cson
+++ b/dev/standard.cson
@@ -61,7 +61,7 @@
     category: 'other'
     name: 'priority_road'
     elements: [
-      { type: 'diamond-bg', value: 'yellow' }
+      { type: 'diamond-bg', value: 'yellow-dark' }
       { type: 'diamond-o', value: 'white' }
     ]
 
@@ -141,7 +141,7 @@
       { type: 'tri-o', value: 'red' }
       { type: 'traffic-l-bg', value: 'black' }
       { type: 'traffic-l-r', value: 'red' }
-      { type: 'traffic-l-y', value: 'yellow' }
+      { type: 'traffic-l-y', value: 'yellow-dark' }
       { type: 'traffic-l-g', value: 'green' }
     ]
 

--- a/stylesheets/extend.css
+++ b/stylesheets/extend.css
@@ -87,19 +87,23 @@
 }
 
 .t-c-red {
-  color: red;
+  color: #c1121c;
 }
 
 .t-c-blue {
-  color: mediumblue;
+  color: #154889;
 }
 
 .t-c-black {
   color: black;
 }
 
+.t-c-yellow-dark {
+  color: #f0ca00;
+}
+
 .t-c-yellow {
-  color: yellow;
+  color: #fecf33;
 }
 
 .t-c-grey {
@@ -107,5 +111,5 @@
 }
 
 .t-c-green {
-  color: darkgreen;
+  color: #008754;
 }


### PR DESCRIPTION
I've defined the sign-colours as RGB-values instead of the named HTML-values.
The new colors are darker, but more realistic. I've taken them from the following websites:
https://de.wikipedia.org/wiki/Bildtafel_der_Verkehrszeichen_in_der_Bundesrepublik_Deutschland_seit_2009
https://de.wikipedia.org/wiki/Bildtafel_der_Verkehrszeichen_in_den_Vereinigten_Staaten
