### PR TITLE
Modified styling of gh-pages and made version-switching easier

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,2 +1,3 @@
 name: Traffico
+version: 0.0.7
 highlighter: pygments

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,7 +7,7 @@
     <meta name="description" content="Traffico, Open Traffic Sign Font">
     <link href="{{ site.baseurl }}/stylesheets/main.css" rel="stylesheet">
     <link href="{{ site.baseurl }}/stylesheets/syntax.css" rel="stylesheet">
-    <link href="https://raw.githubusercontent.com/mapillary/traffico-release/master/stylesheets/traffico.css" rel="stylesheet">
+    <link href="https://cdn.rawgit.com/mapillary/traffico-release/v{{ site.version }}/stylesheets/traffico.css" rel="stylesheet">
   </head>
 <body>
   <header>

--- a/_sass/base/_base.scss
+++ b/_sass/base/_base.scss
@@ -12,8 +12,8 @@ p {
   line-height: 1.4em;
 }
 
-.example {
-  font-size: 2em;
+span.example {
+  font-size: 4em;
 }
 
 footer {

--- a/_sass/layout/_landing.scss
+++ b/_sass/layout/_landing.scss
@@ -3,8 +3,9 @@
   background-color: $color--main;
   padding: 1em;
   color: $color--white;
-  min-height: 20em;
+  min-height: 21em;
   position: relative;
+  box-shadow: 0 0 10px rgba(0,0,0,.3) inset;
 }
 
 .splash {
@@ -13,11 +14,20 @@
   left: 0;
   right: 0;
 
-  &__button {
-    margin-top: 2em;
-    font-size: 1em;
-    background-color: $color--white;
+  h1, h2 {
+    text-shadow: 4px 4px 8px rgba(0,0,0,.25);
+  }
 
+  a.splash__button {
+    margin-top: 1em;
+    font-size: 1em;
+    color:$color--black;
+    background-color: $color--white;
+    box-shadow: 5px 5px 10px rgba(0,0,0,.25);
+
+    &:hover {
+      box-shadow: 2.5px 2.5px 5px rgba(0,0,0,.25);
+    }
     @media screen and (min-width: 567px) {
       font-size: 1.5em;
     }
@@ -42,21 +52,49 @@ a.splash__source {
   }
 
   &__install {
-    color: $color--black;
+    color: $color--white;
+    padding: .1em .4em;
+    border-radius:.25em;
+    background: $color--black;
+    span {
+      font-weight:bold;
+      color: $color--main;
+    }
   }
 
   &__love {
-    font-size: 0.5em;
     font-weight: 200;
     text-align: center;
     color: $color--grey;
+    display:block;
+    position:relative;
+    margin:1em 0 0;
+    p {
+      font-size: 0.5em;
+      background:white;
+      display:inline-block;
+      padding:0 1em;
+    }
+    hr {
+      margin-bottom:-.9em;
+      background: $color--grey;
+      height:1px;
+      border:none;
+    }
+  }
+}
+
+.github-ribbon {
+  display:none;
+  @media screen and (min-width: 567px) {
+    display:block;
   }
 }
 
 .sample-set {
   font-size: 4em;
   margin: 1em auto;
-  max-width: 650px;
+  text-align:center;
 
   &__more {
     margin: 10px;

--- a/index.html
+++ b/index.html
@@ -4,11 +4,13 @@ title: Traffico
 subtitle: An Open Source Traffic Sign Font
 ---
 
+<a href="https://github.com/mapillary/traffico" class="github-ribbon"><img style="z-index:5;position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
+
 <div class="splash-container">
   <div class="splash">
     <h1 class="splash__title">{{ page.title }}</h1>
     <h2 class="">{{ page.subtitle }}</h2>
-    <a class="pure-button splash__button" href="https://github.com/mapillary/traffico-release/releases/tag/v{{ site.version }}">Download v{{ site.version }} (fonts, stylesheets & json)</a>
+    <a class="pure-button splash__button" href="https://github.com/mapillary/traffico-release/releases/tag/v{{ site.version }}"><strong>Download v{{ site.version }}</strong><br>fonts, stylesheets &amp; json</a>
     <a class="splash__source" href="https://github.com/mapillary/traffico">Check out the source code</a>
   </div>
 </div>
@@ -18,7 +20,7 @@ subtitle: An Open Source Traffic Sign Font
     the <a href="{{ site.baseurl }}/shapes">Shapes</a> page for available shapes or <a href="{{ site.baseurl }}/examples">Examples</a> for what is available in the .json files.</p>
   <p class="content__lead">Install from command line:
     <code class="content__install">
-      $ bower install traffico
+      $ bower install <span>traffico</span>
     </code>
   </p>
 
@@ -77,9 +79,10 @@ subtitle: An Open Source Traffic Sign Font
 
       <a class="sample-set__more" href="{{baseurl}}/examples.html">More examples</a>
 
-      <p class="content__love">
-        Made with &hearts; at <a href="https://mapillary.com">Mapillary</a>
-      </p>
+      <div class="content__love">
+        <hr />
+        <p>Made with &hearts; at <a href="https://mapillary.com">Mapillary</a></p>
+      </div>
 
     </div>
   </div>
@@ -88,7 +91,7 @@ subtitle: An Open Source Traffic Sign Font
       <h3 class="content__subhead">A collection of layers</h3>
       <p>Traffico is a collection of vector shapes, that are meant to be stacked on one another</p>
 
-      <p>Fox example, to build a &lsquo;Warning of danger ahead&rsquo; sign, after attaching stylesheets and the font files:</p>
+      <p>For example, to build a &lsquo;Warning of danger ahead&rsquo; sign, after attaching stylesheets and the font files:</p>
 {% highlight css %}
 <span class="t">
   <i class="t-tri-bg t-c-yellow"></i>
@@ -112,23 +115,25 @@ subtitle: An Open Source Traffic Sign Font
         <h3 class="content__subhead">Generative templates</h3>
         <p>With every Traffico release, there is a set of .json files attached, which provide for a good foundation for generating templates in a framework of your choice.</p>
 {% highlight json %}
-"information_pedestrian_crossing": {
-  "category":"other",
-  "name":"pedestrian crossing",
-  "elements":[
-    {
-      "type":"square-bg",
-      "value":"blue"
-    },
-    {
-      "type":"tri-bg-in",
-      "value":"white"
-    },
-    {
-      "type":"pedestrian-crossing",
-      "value":"black"
-    }
-  ]
+{
+  "information_pedestrian_crossing": {
+    "category":"other",
+    "name":"pedestrian crossing",
+    "elements":[
+      {
+        "type":"square-bg",
+        "value":"blue"
+      },
+      {
+        "type":"tri-bg-in",
+        "value":"white"
+      },
+      {
+        "type":"pedestrian-crossing",
+        "value":"black"
+      }
+    ]
+  }
 }
 {% endhighlight %}
     </div>

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@ subtitle: An Open Source Traffic Sign Font
   <div class="splash">
     <h1 class="splash__title">{{ page.title }}</h1>
     <h2 class="">{{ page.subtitle }}</h2>
-    <a class="pure-button splash__button" href="https://github.com/mapillary/traffico-release">Download v0.0.7 (fonts, stylesheets & json)</a>
+    <a class="pure-button splash__button" href="https://github.com/mapillary/traffico-release/releases/tag/v{{ site.version }}">Download v{{ site.version }} (fonts, stylesheets & json)</a>
     <a class="splash__source" href="https://github.com/mapillary/traffico">Check out the source code</a>
   </div>
 </div>

--- a/stylesheets/main.scss
+++ b/stylesheets/main.scss
@@ -2,8 +2,7 @@
 ---
 
 @import
-  "vendors/pure.min",
-  "vendors/traffico";
+  "vendors/pure.min";
 
 @import
   "utils/variables";


### PR DESCRIPTION
- Obtains stylesheet from rawgit.com, because raw.githubusercontent.com does only deliver files with type text/plain (not text/css)
- The current version-number is controlled in the central config-file (all links are updated accordingly)
- Modified styling and added Github-"Fork me"-ribbon (invisible on small screens)
