### PR TITLE
add a bus icon

### DIFF
--- a/icons/bus.svg
+++ b/icons/bus.svg
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="647.45"
+   height="298.41"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="bus.svg">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     borderopacity="1"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.68"
+     inkscape:cx="464.38"
+     inkscape:cy="119.78"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1024"
+     inkscape:window-height="578"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:snap-grids="false"
+     inkscape:snap-bbox="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0" />
+  <g
+     inkscape:label="Laag 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-45.4928,-61.094623)"
+     display="inline">
+    <path
+       d="M 553 0 C 387.19953 0.14929688 198.93625 2.40625 40.9375 0.875 C 35.6275 8.525 28.085 19.445 29.125 29.375 C 29.365 37.285 44.7 38.88875 35 48.71875 C 23.41 75.75875 11.80875 102.80375 0.21875 129.84375 C 5.10875 139.21375 10.87125 148.365 8.78125 159.375 L 8.78125 221.28125 C -2.56875 222.98125 0.38875 233.515 0.21875 242.125 C 1.44875 249.305 15.7925 243.11625 22.3125 244.90625 C 44.9625 244.46625 67.6 244.03375 90.25 243.59375 C 90.93 204.98375 133.21125 170.55 170.78125 186.5 C 193.80125 195.16 210.19125 219.42125 209.53125 243.78125 C 277.22125 243.83125 344.8725 243.8875 412.5625 243.9375 C 410.9525 202.1675 459.6325 169.75625 497.5625 187.40625 C 519.41288 196.40229 534.48512 218.9976 534.21875 242.65625 C 571.02993 237.31196 608.73168 232.77831 645 227.03125 C 654.14 212.52125 634.87625 213.83375 632.15625 205.34375 C 631.71625 165.86375 633.925 126.27 628.875 87 C 627.505 74.66 626.90375 61.96125 625.84375 49.78125 C 617.57375 40.53125 629.415 37.06125 635.875 32.03125 C 644.125 28.60125 635.125 17.98 634.375 12 C 629.48302 3.650564 630.35303 1.7735059 630.6875 1.46875 C 630.31285 1.6288281 628.57625 1.92 622.53125 0.09375 C 599.915 0.0125 576.68578 -0.021328125 553 0 z M 534.21875 242.65625 C 534.13585 242.66829 534.05164 242.67546 533.96875 242.6875 L 534.21875 242.6875 C 534.21887 242.67708 534.21863 242.66667 534.21875 242.65625 z M 601 29 L 613.5 118.71875 L 555.53125 118.71875 L 555.53125 29.71875 L 601 29 z M 141.4375 29.28125 L 229.84375 29.28125 L 229.84375 119.65625 L 141.4375 119.65625 L 141.4375 29.28125 z M 245.46875 29.28125 L 333.90625 29.28125 L 333.90625 119.65625 L 245.46875 119.65625 L 245.46875 29.28125 z M 349.53125 29.28125 L 437.9375 29.28125 L 437.9375 119.65625 L 349.53125 119.65625 L 349.53125 29.28125 z M 453.6875 29.28125 L 539.15625 29.28125 L 539.15625 119.65625 L 453.6875 119.65625 L 453.6875 29.28125 z M 75.78125 37.03125 L 126.5625 37.03125 L 126.5625 149.59375 L 39.71875 148.84375 L 27.96875 123.09375 L 75.78125 37.03125 z "
+       id="path3147"
+       transform="translate(45.4928,61.094623)" />
+    <path
+       sodipodi:type="arc"
+       id="path3050"
+       sodipodi:cx="217.14"
+       sodipodi:cy="320.93"
+       sodipodi:rx="54.29"
+       sodipodi:ry="54.29"
+       d="m 271.43,320.92999 c 0,29.98354 -24.30646,54.29 -54.29,54.29 -29.98354,0 -54.29,-24.30646 -54.29,-54.29 0,-29.98354 24.30646,-54.29 54.29,-54.29 29.98354,0 54.29,24.30646 54.29,54.29 z"
+       transform="matrix(1,0,0,-1,-22,626.15296)"
+       fill="#000" />
+    <path
+       transform="matrix(1,0,0,-1,302.85715,626.15296)"
+       d="m 271.43,320.92999 c 0,29.98354 -24.30646,54.29 -54.29,54.29 -29.98354,0 -54.29,-24.30646 -54.29,-54.29 0,-29.98354 24.30646,-54.29 54.29,-54.29 29.98354,0 54.29,24.30646 54.29,54.29 z"
+       sodipodi:ry="54.29"
+       sodipodi:rx="54.29"
+       sodipodi:cy="320.93"
+       sodipodi:cx="217.14"
+       id="path3052"
+       sodipodi:type="arc"
+       fill="#000" />
+  </g>
+</svg>


### PR DESCRIPTION
for:
- prohibition signs like C07A/C07B
- parking signs like E08-2/E08-4
- F13/F14 (buslane) and F19/F20 (bus and truck lane)
