### PR TITLE
Started file with Dutch signs

### DIFF
--- a/dev/nl.cson
+++ b/dev/nl.cson
@@ -1,0 +1,8 @@
+information_cycleway:
+  category: 'information'
+  name: 'non-compulsory cycleway'
+  elements: [
+    { type: 'square-rounded', color: 'white', transform: 'scale(1,.3)' }
+    { type: 'square-rounded', color: 'blue', transform: 'scale(.95,.25)' }
+    { type: 'content-4', color: 'white', content: 'fietspad' }
+  ]


### PR DESCRIPTION
New signs:
- `information_cycleway` as requested in mapillary/mapillary_issues#625
- <del>`danger_railway_crossing_unsecured`</del> (this sign will be part of `europe.cson` instead, because it is quite common)

![nl](https://cloud.githubusercontent.com/assets/3904348/6232708/2c6ce516-b6ce-11e4-8eb0-e1e0266bad3b.png)
