### PR TITLE
Adds new signs and fixes dependency-problem in gulpfile.js

### DIFF
--- a/dev/at.cson
+++ b/dev/at.cson
@@ -1,0 +1,8 @@
+information_border_at:
+  category: 'information'
+  name: 'European border crossing into Austria'
+  elements: [
+    { type: 'square-rounded', color: 'blue' }
+    { type: 'europe_stars', color: 'yellow' }
+    { type: 'content-5', color: 'white', content: 'ÖSTERREICH', transform: 'scale(.75)'}
+  ]

--- a/dev/be.cson
+++ b/dev/be.cson
@@ -1,6 +1,6 @@
 information_border_be_nl:
   category: 'information'
-  name: 'European border crossing into Belgium'
+  name: 'European border crossing into Belgium from the Netherlands'
   elements: [
     { type: 'square-rounded', color: 'blue' }
     { type: 'europe_stars', color: 'yellow' }
@@ -9,7 +9,7 @@ information_border_be_nl:
 
 information_border_be_fr:
   category: 'information'
-  name: 'European border crossing into Belgium'
+  name: 'European border crossing into Belgium from France'
   elements: [
     { type: 'square-rounded', color: 'blue' }
     { type: 'europe_stars', color: 'yellow' }

--- a/dev/be.cson
+++ b/dev/be.cson
@@ -1,0 +1,17 @@
+information_border_be_nl:
+  category: 'information'
+  name: 'European border crossing into Belgium'
+  elements: [
+    { type: 'square-rounded', color: 'blue' }
+    { type: 'europe_stars', color: 'yellow' }
+    { type: 'content-5', color: 'white', content: 'België' }
+  ]
+
+information_border_be_fr:
+  category: 'information'
+  name: 'European border crossing into Belgium'
+  elements: [
+    { type: 'square-rounded', color: 'blue' }
+    { type: 'europe_stars', color: 'yellow' }
+    { type: 'content-5', color: 'white', content: 'Belgique' }
+  ]

--- a/dev/cz.cson
+++ b/dev/cz.cson
@@ -1,0 +1,9 @@
+information_border_cz:
+  category: 'information'
+  name: 'European border crossing into Czech Republic'
+  elements: [
+    { type: 'square-rounded', color: 'blue' }
+    { type: 'europe_stars', color: 'yellow' }
+    { type: 'content-5', color: 'white', content: 'České', transform: 'translate(0,-50%)'}
+    { type: 'content-5', color: 'white', content: 'republika', transform: 'translate(0,50%)' }
+  ]

--- a/dev/de.cson
+++ b/dev/de.cson
@@ -19,6 +19,17 @@ information_bus_stop:
     { type: 'h', color: 'green', transform: '{fit_border_circle}'}
   ]
 
+information_border_de:
+  category: 'information'
+  name: 'European border crossing into Germany'
+  elements: [
+    { type: 'square-rounded', color: 'blue' }
+    { type: 'europe_stars', color: 'yellow' }
+    { type: 'content-5', color: 'white', content: 'Bundes-', transform: 'scale(.9) translate(0,-130%)'}
+    { type: 'content-5', color: 'white', content: 'republik', transform: 'scale(.9) translate(0,-30%)' }
+    { type: 'content-5', color: 'white', content: 'Deutschland', transform: 'scale(.9) translate(0,70%)' }
+  ]
+
 priority_priority_road_end:
   category: 'priority'
   name: 'end of priority road'

--- a/dev/dk.cson
+++ b/dev/dk.cson
@@ -1,3 +1,15 @@
+danger_level_crossing:
+  category: 'danger'
+  name: 'level crossing'
+  elements: [
+    { type: 'square-angular', color: 'red', transform: 'rotate(60deg) scale(.2,1)' }
+    { type: 'square-angular', color: 'red', transform: 'rotate(-60deg) scale(.2,1)' }
+    { type: 'square-angular', color: 'white', transform: 'rotate(60deg) scale(.1,.5) translate(50%,50%)' }
+    { type: 'square-angular', color: 'white', transform: 'rotate(-60deg) scale(.1,.5) translate(-50%,50%)' }
+    { type: 'square-angular', color: 'white', transform: 'rotate(60deg) scale(.1,.5) translate(-50%,-50%)' }
+    { type: 'square-angular', color: 'white', transform: 'rotate(-60deg) scale(.1,.5) translate(50%,-50%)' }
+  ]
+
 information_border_dk:
   category: 'information'
   name: 'European border crossing into Denmark'

--- a/dev/dk.cson
+++ b/dev/dk.cson
@@ -1,0 +1,8 @@
+information_border_dk:
+  category: 'information'
+  name: 'European border crossing into Denmark'
+  elements: [
+    { type: 'square-rounded', color: 'blue' }
+    { type: 'europe_stars', color: 'yellow' }
+    { type: 'content-5', color: 'white', content: 'Danmark' }
+  ]

--- a/dev/ee.cson
+++ b/dev/ee.cson
@@ -1,0 +1,8 @@
+information_border_ee:
+  category: 'information'
+  name: 'European border crossing into Estonia'
+  elements: [
+    { type: 'square-rounded', color: 'blue' }
+    { type: 'europe_stars', color: 'yellow' }
+    { type: 'content-5', color: 'white', content: 'EESTI' }
+  ]

--- a/dev/es.cson
+++ b/dev/es.cson
@@ -1,0 +1,8 @@
+information_border_es:
+  category: 'information'
+  name: 'European border crossing into Spain'
+  elements: [
+    { type: 'square-rounded', color: 'blue' }
+    { type: 'europe_stars', color: 'yellow' }
+    { type: 'content-5', color: 'white', content: 'ESPAÑA' }
+  ]

--- a/dev/europe.cson
+++ b/dev/europe.cson
@@ -53,6 +53,16 @@ danger_construction:
     { type: 'roadworks', color: 'black', transform: 'scale(.7) translate(0,20%)' }
   ]
 
+danger_contraflow:
+  category: 'danger'
+  name: 'contraflow'
+  elements: [
+    { type: 'tri-rounded', color: 'red' }
+    { type: 'tri-angular', color: 'white', transform: '{inner_triangle}' }
+    { type: 'DE-arrow-up', color: 'black', transform: '{center2tri} scale(.35) translate(-25%,5%) rotate(180deg)' }
+    { type: 'DE-arrow-up', color: 'black', transform: '{center2tri} scale(.35) translate(25%,-5%)' }
+  ]
+
 danger_crossroad:
   category: 'danger'
   name: 'crossroad with priority to the right ahead'

--- a/dev/fi.cson
+++ b/dev/fi.cson
@@ -1,0 +1,10 @@
+information_border_fi:
+  category: 'information'
+  name: 'European border crossing into Finland'
+  elements: [
+    { type: 'square-rounded', color: 'blue' }
+    { type: 'europe_stars', color: 'yellow' }
+    { type: 'content-5', color: 'white', content: 'SUOMI', transform: 'translate(0,-100%)'}
+    { type: 'content-5', color: 'white', content: 'FINLAND', transform: 'translate(0,0)' }
+    { type: 'content-5', color: 'white', content: 'SUOPMA', transform: 'translate(0,100%)' }
+  ]

--- a/dev/fr.cson
+++ b/dev/fr.cson
@@ -1,0 +1,8 @@
+information_border_fr:
+  category: 'information'
+  name: 'European border crossing into France'
+  elements: [
+    { type: 'square-rounded', color: 'blue' }
+    { type: 'europe_stars', color: 'yellow' }
+    { type: 'content-5', color: 'white', content: 'FRANCE' }
+  ]

--- a/dev/gr.cson
+++ b/dev/gr.cson
@@ -1,4 +1,4 @@
-information_border_cz:
+information_border_gr:
   category: 'information'
   name: 'European border crossing into Greece'
   elements: [

--- a/dev/gr.cson
+++ b/dev/gr.cson
@@ -1,0 +1,9 @@
+information_border_cz:
+  category: 'information'
+  name: 'European border crossing into Greece'
+  elements: [
+    { type: 'square-rounded', color: 'blue' }
+    { type: 'europe_stars', color: 'yellow' }
+    { type: 'content-5', color: 'yellow', content: 'EΛΛAΣ', transform: 'translate(0,-50%)'}
+    { type: 'content-5', color: 'white', content: 'GREECE', transform: 'translate(0,50%)' }
+  ]

--- a/dev/hu.cson
+++ b/dev/hu.cson
@@ -1,0 +1,8 @@
+information_border_hu:
+  category: 'information'
+  name: 'European border crossing into Hungary'
+  elements: [
+    { type: 'square-rounded', color: 'blue' }
+    { type: 'europe_stars', color: 'yellow' }
+    { type: 'content-5', color: 'white', content: 'Magyarország', transform: 'scale(.75)' }
+  ]

--- a/dev/it.cson
+++ b/dev/it.cson
@@ -1,0 +1,8 @@
+information_border_is:
+  category: 'information'
+  name: 'European border crossing into Italy'
+  elements: [
+    { type: 'square-rounded', color: 'blue' }
+    { type: 'europe_stars', color: 'yellow' }
+    { type: 'content-5', color: 'white', content: 'ITALIA' }
+  ]

--- a/dev/lt.cson
+++ b/dev/lt.cson
@@ -1,0 +1,9 @@
+information_border_lt:
+  category: 'information'
+  name: 'European border crossing into Lithuania'
+  elements: [
+    { type: 'square-rounded', color: 'blue' }
+    { type: 'europe_stars', color: 'yellow' }
+    { type: 'content-5', color: 'white', content: 'Lietuvos', transform: 'translate(0,-80%)' }
+    { type: 'content-5', color: 'white', content: 'Respublika', transform: 'translate(0,20%)' }
+  ]

--- a/dev/lu.cson
+++ b/dev/lu.cson
@@ -1,6 +1,6 @@
 information_border_lu_fr:
   category: 'information'
-  name: 'European border crossing into Luxembourg'
+  name: 'European border crossing into Luxembourg from France'
   elements: [
     { type: 'square-rounded', color: 'blue' }
     { type: 'europe_stars', color: 'yellow' }
@@ -9,7 +9,7 @@ information_border_lu_fr:
 
 information_border_lu_de:
   category: 'information'
-  name: 'European border crossing into Luxembourg'
+  name: 'European border crossing into Luxembourg from Germany'
   elements: [
     { type: 'square-rounded', color: 'blue' }
     { type: 'europe_stars', color: 'yellow' }

--- a/dev/lu.cson
+++ b/dev/lu.cson
@@ -1,0 +1,9 @@
+information_border_lu_fr:
+  category: 'information'
+  name: 'European border crossing into Luxembourg'
+  elements: [
+    { type: 'square-rounded', color: 'blue' }
+    { type: 'europe_stars', color: 'yellow' }
+    { type: 'content-5', color: 'white', content: 'Luxembourg', transform: 'scale(.85)' }
+  ]
+

--- a/dev/lu.cson
+++ b/dev/lu.cson
@@ -7,3 +7,11 @@ information_border_lu_fr:
     { type: 'content-5', color: 'white', content: 'Luxembourg', transform: 'scale(.85)' }
   ]
 
+information_border_lu_de:
+  category: 'information'
+  name: 'European border crossing into Luxembourg'
+  elements: [
+    { type: 'square-rounded', color: 'blue' }
+    { type: 'europe_stars', color: 'yellow' }
+    { type: 'content-5', color: 'white', content: 'Luxemburg', transform: 'scale(.85)' }
+  ]

--- a/dev/lv.cson
+++ b/dev/lv.cson
@@ -1,0 +1,8 @@
+information_border_lv:
+  category: 'information'
+  name: 'European border crossing into Latvia'
+  elements: [
+    { type: 'square-rounded', color: 'blue' }
+    { type: 'europe_stars', color: 'yellow' }
+    { type: 'content-5', color: 'white', content: 'LATVIJA' }
+  ]

--- a/dev/nl.cson
+++ b/dev/nl.cson
@@ -1,12 +1,3 @@
-information_cycleway:
-  category: 'information'
-  name: 'non-compulsory cycleway'
-  elements: [
-    { type: 'square-rounded', color: 'white', transform: 'scale(1,.3)' }
-    { type: 'square-rounded', color: 'blue', transform: 'scale(.95,.25)' }
-    { type: 'content-4', color: 'white', content: 'fietspad' }
-  ]
-
 information_border_nl:
   category: 'information'
   name: 'European border crossing into the Netherlands'
@@ -14,4 +5,13 @@ information_border_nl:
     { type: 'square-rounded', color: 'blue' }
     { type: 'europe_stars', color: 'yellow' }
     { type: 'content-5', color: 'white', content: 'Nederland' }
+  ]
+
+information_cycleway:
+  category: 'information'
+  name: 'non-compulsory cycleway'
+  elements: [
+    { type: 'square-rounded', color: 'white', transform: 'scale(1,.3)' }
+    { type: 'square-rounded', color: 'blue', transform: 'scale(.95,.25)' }
+    { type: 'content-4', color: 'white', content: 'fietspad' }
   ]

--- a/dev/nl.cson
+++ b/dev/nl.cson
@@ -6,3 +6,12 @@ information_cycleway:
     { type: 'square-rounded', color: 'blue', transform: 'scale(.95,.25)' }
     { type: 'content-4', color: 'white', content: 'fietspad' }
   ]
+
+information_border_nl:
+  category: 'information'
+  name: 'European border crossing into the Netherlands'
+  elements: [
+    { type: 'square-rounded', color: 'blue' }
+    { type: 'europe_stars', color: 'yellow' }
+    { type: 'content-5', color: 'white', content: 'Nederland' }
+  ]

--- a/dev/pl.cson
+++ b/dev/pl.cson
@@ -1,0 +1,9 @@
+information_border_pl:
+  category: 'information'
+  name: 'European border crossing into Poland'
+  elements: [
+    { type: 'square-rounded', color: 'blue' }
+    { type: 'europe_stars', color: 'yellow' }
+    { type: 'content-5', color: 'white', content: 'Rzeczpospolita', transform: 'translate(0,-70%) scale(.7)' }
+    { type: 'content-5', color: 'white', content: 'Polska', transform: 'translate(0,40%)' }
+  ]

--- a/dev/se.cson
+++ b/dev/se.cson
@@ -1,8 +1,8 @@
-information_border_it:
+information_border_se:
   category: 'information'
-  name: 'European border crossing into Italy'
+  name: 'European border crossing into Sweden'
   elements: [
     { type: 'square-rounded', color: 'blue' }
     { type: 'europe_stars', color: 'yellow' }
-    { type: 'content-5', color: 'white', content: 'ITALIA' }
+    { type: 'content-5', color: 'white', content: 'SVERIGE' }
   ]

--- a/dev/si.cson
+++ b/dev/si.cson
@@ -1,0 +1,8 @@
+information_border_si:
+  category: 'information'
+  name: 'European border crossing into Slovenia'
+  elements: [
+    { type: 'square-rounded', color: 'blue' }
+    { type: 'europe_stars', color: 'yellow' }
+    { type: 'content-5', color: 'white', content: 'SLOVENIA', transform: 'scale(.85)' }
+  ]

--- a/dev/sk.cson
+++ b/dev/sk.cson
@@ -1,0 +1,8 @@
+information_border_sk:
+  category: 'information'
+  name: 'European border crossing into Slovakia'
+  elements: [
+    { type: 'square-rounded', color: 'blue' }
+    { type: 'europe_stars', color: 'yellow' }
+    { type: 'content-5', color: 'white', content: 'SLOVENSKO', transform: 'scale(.8)' }
+  ]

--- a/dev/uk.cson
+++ b/dev/uk.cson
@@ -1,0 +1,27 @@
+danger_contraflow:
+  category: 'danger'
+  name: 'contraflow'
+  elements: [
+    { type: 'tri-rounded', color: 'red' }
+    { type: 'tri-angular', color: 'white', transform: '{inner_triangle}' }
+    { type: 'DE-arrow-up', color: 'black', transform: '{center2tri} scale(.35) translate(-25%,-5%)' }
+    { type: 'DE-arrow-up', color: 'black', transform: '{center2tri} scale(.35) translate(25%,5%) rotate(180deg)' }
+  ]
+
+mandatory_roundabout:
+  category: 'mandatory'
+  name: 'roundabout'
+  elements: [
+    { type: 'circle-bg', color: 'blue' }
+    { type: 'roundabout', color: 'white', transform: 'scale(-1.25,1.25)' }
+  ]
+
+prohibitory_overtaking:
+  category: 'prohibitory'
+  name: 'no overtaking'
+  elements: [
+    { type: 'circle-bg', color: 'white' }
+    { type: 'circle-o', color: 'red' }
+    { type: 'car-left', color: 'black' }
+    { type: 'car-right', color: 'red' }
+  ]

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,19 +7,21 @@ var sass = require('gulp-sass');
 
 gulp.task('clean', shell.task(['rm -f .fontcustom-manifest.json', 'rm -rf ./build/']));
 
-gulp.task('compile', ['clean'], shell.task('fontcustom compile'));
+gulp.task('compile-font', ['clean'], shell.task('fontcustom compile'));
 
-gulp.task('cson', function() {
-  gulp.src('dev/*.cson')
+gulp.task('cson-signs', function() {
+  return gulp.src('dev/*.cson')
     .pipe(cson())
     .pipe(gulp.dest('build/json'));
+});
 
-  gulp.src('stylesheets/transformations.cson')
+gulp.task('cson-transformations', function() {
+  return gulp.src('stylesheets/transformations.cson')
     .pipe(cson())
     .pipe(gulp.dest('build'))
 });
 
-gulp.task('concat', ['compile'], function() {
+gulp.task('concat-traffico-css', ['compile-font'], function() {
   return gulp.src(['build/stylesheets/traffico.css', 'stylesheets/extend.css'])
     .pipe(concat('traffico.css'))
     .pipe(gulp.dest('build/stylesheets'))
@@ -28,11 +30,13 @@ gulp.task('concat', ['compile'], function() {
 gulp.task('gen-overview-css', function() {
   return gulp.src('stylesheets/examples.scss').pipe(sass()).pipe(gulp.dest('build/stylesheets'));
 });
+
 gulp.task('gen-overview-scss', function() {
   return gulp.src('stylesheets/examples.scss').pipe(gulp.dest('build/gh-pages'));
 });
-gulp.task('gen-overview', ['compile', 'gen-overview-scss', 'gen-overview-css'], function () {
-  return gulp.src('scripts/generate-overview.js', {read:false}).pipe(shell(['node <%= file.path %>']));
+
+gulp.task('gen-overview', ['cson-signs', 'cson-transformations'], function () {
+  return gulp.src('scripts/generate-overview.js').pipe(shell(['node <%= file.path %>']));
 });
 
-gulp.task('default', ['compile', 'concat', 'cson', 'gen-overview']);
+gulp.task('default', ['concat-traffico-css', 'gen-overview', 'gen-overview-scss', 'gen-overview-css']);

--- a/icons/europe_stars.svg
+++ b/icons/europe_stars.svg
@@ -1,0 +1,26 @@
+<svg xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1" width="512" height="512" id="svg2">
+  <defs id="defs5">
+    <g id="star">
+      <g id="cone">
+        <path d="M0 0V1H0.5z" transform="matrix(0.95105652,0.30901699,-0.30901699,0.95105652,0,-1)" id="triangle" />
+        <use transform="scale(-1,1)" id="use1948" x="0" y="0" width="200" height="200" xlink:href="#triangle" />
+      </g>
+      <use transform="matrix(0.30901699,0.95105652,-0.95105652,0.30901699,0,0)" id="use1950" x="0" y="0" width="200" height="200" xlink:href="#cone" />
+      <use transform="matrix(-0.80901699,0.58778525,-0.58778525,-0.80901699,0,0)" id="use1952" x="0" y="0" width="200" height="200" xlink:href="#cone" />
+      <use transform="matrix(-0.80901699,-0.58778525,0.58778525,-0.80901699,0,0)" id="use1954" x="0" y="0" width="200" height="200" xlink:href="#cone" />
+      <use transform="matrix(0.30901699,-0.95105652,0.95105652,0.30901699,0,0)" id="use1956" x="0" y="0" width="200" height="200" xlink:href="#cone" />
+    </g>
+  </defs>
+  <g transform="matrix(36.828934,0,0,36.828907,256,261.23135)" id="g1960" fill="#fc0">
+    <use id="use1962" x="0" y="-6" width="200" height="200" xlink:href="#star" />
+    <g id="rtl">
+      <use transform="matrix(0.309017,0.951057,-0.951057,0.309017,-3,5.196152)" id="use1965" x="0" y="0" width="200" height="200" xlink:href="#star" />
+      <use transform="matrix(0.309017,0.951057,-0.951057,0.309017,-5.196152,3)" id="use1967" x="0" y="0" width="200" height="200" xlink:href="#star" />
+      <use id="use1969" x="6" y="0" width="200" height="200" xlink:href="#star" />
+      <use transform="matrix(-0.809017,0.587785,-0.587785,-0.809017,-5.196152,-3)" id="use1971" x="0" y="0" width="200" height="200" xlink:href="#star" />
+      <use transform="matrix(-0.809017,-0.587785,0.587785,-0.809017,-3,-5.196152)" id="use1973" x="0" y="0" width="200" height="200" xlink:href="#star" />
+    </g>
+    <use id="use1975" x="0" y="6" width="200" height="200" xlink:href="#star" />
+    <use transform="scale(-1,1)" id="use1977" x="0" y="0" width="200" height="200" xlink:href="#rtl" />
+  </g>
+</svg>

--- a/stylesheets/extend.css
+++ b/stylesheets/extend.css
@@ -45,6 +45,15 @@
   font-size: 22.5%;
 }
 
+.t-content-5 {
+  font-family: Helvetica, Arial, sans-serif;
+  font-weight: normal;
+  font-style: normal;
+  font-size: 15%;
+  letter-spacing:0;
+  top:50%;
+}
+
 /** Colours */
 
 .t-c-white {


### PR DESCRIPTION
This is built on top of mapillary/traffico#26.
### Fixes problem with dependencies between gulp-tasks

The script `generate-overview.js` was started before all *.cson files were converted, which resulted in an incomplete `sign-overview.html`.

I've now renamed/split/reordered some tasks, so this problem should be solved. The new task dependencies look like this (boxes are the tasks, arrows point to dependencies):

![gulp-dependencies](https://cloud.githubusercontent.com/assets/3904348/6320709/d4d89ec8-bae5-11e4-8df9-4c05218846b9.png)
### New signs
#### `dk.cson`
- danger_level_crossing

![dk](https://cloud.githubusercontent.com/assets/3904348/6320679/0488fed4-bae5-11e4-8c2e-cc9f67a4269a.png)
#### `europe.cson`
- danger_contraflow

![europe](https://cloud.githubusercontent.com/assets/3904348/6320680/0ae8b04e-bae5-11e4-8031-df572fcef3b2.png)
#### `uk.cson`
- danger_contraflow
- mandatory_roundabout
- prohibitory_overtaking

![uk](https://cloud.githubusercontent.com/assets/3904348/6320683/10e8e0cc-bae5-11e4-81c2-e7449bf16f98.png)
### Other minor changes
- Ordered `nl.cson` alphabetically
- Fixed typo in `gr.cson`
- Changed description of border-signs that are different depending on
  which country you come from
