### PR TITLE
Added .travis.yml and supplementary signs. Fixed gulpfile.js and incremented versions of npm-packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
 language: node_js
-node_js:
-  - "0.11"
-  - "0.10"
+cache: apt
+node_js: "0.10"
 before_script:
-  - npm install -g gulp
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq fontforge node ruby1.9.1 ruby1.9.1-dev
+  - wget http://people.mozilla.com/~jkew/woff/woff-code-latest.zip
+  - unzip woff-code-latest.zip -d sfnt2woff && cd sfnt2woff && make && sudo mv sfnt2woff /usr/local/bin/ && cd ..
+  - rvmsudo gem install fontcustom
+  - npm install --global gulp
 script:
   - gulp
-  - exit $(expr `find dev/*.cson | wc -l` != `find build/json/*.json | wc -l`)
+  - exit $(expr `find ./dev/*.cson | wc -l` != `find ./build/json/*.json | wc -l`)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 language: node_js
-cache: apt
 node_js: "0.10"
-before_script:
+cache:
+  apt: true
+  directories:
+  - node_modules
+before_install:
   - sudo apt-get update -qq
+install:
   - sudo apt-get install -qq fontforge node ruby1.9.1 ruby1.9.1-dev
   - wget http://people.mozilla.com/~jkew/woff/woff-code-latest.zip
   - unzip woff-code-latest.zip -d sfnt2woff && cd sfnt2woff && make && sudo mv sfnt2woff /usr/local/bin/ && cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
   - wget http://people.mozilla.com/~jkew/woff/woff-code-latest.zip
   - unzip woff-code-latest.zip -d sfnt2woff && cd sfnt2woff && make && sudo mv sfnt2woff /usr/local/bin/ && cd ..
   - rvmsudo gem install fontcustom
-  - npm install --global gulp
+  - npm install
 script:
   - gulp
   - scripts/check_build

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ before_script:
   - npm install --global gulp
 script:
   - gulp
-  - exit $(expr `find ./dev/*.cson | wc -l` != `find ./build/json/*.json | wc -l`)
+  - scripts/check_build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: node_js
+node_js:
+  - "0.11"
+  - "0.10"
+before_script:
+  - npm install -g gulp
+script:
+  - gulp
+  - exit $(expr `find dev/*.cson | wc -l` != `find build/json/*.json | wc -l`)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# traffico
+# traffico [![Build Status](https://travis-ci.org/mapillary/traffico.svg?branch=master)](https://travis-ci.org/floscher/traffico)
 An Open Source Traffic Sign Font. Read more on [traffico.io](http://traffico.io/)
 
 ## Getting the dependencies

--- a/dev/de.cson
+++ b/dev/de.cson
@@ -103,6 +103,24 @@ supplementary_destination:
     { type: 'content-4', color: 'black', content: 'frei', transform: 'translate(0,45%) scale(.8)'}
   ]
 
+supplementary_disabled:
+  category: 'supplementary'
+  name: 'for disabled people'
+  elements: [
+    { type: 'square-rounded', color: 'black', transform: 'scale(1,.5)'}
+    { type: 'square-rounded', color: 'white', transform: 'scale(.95, .45)'}
+    { type: 'disabled-p', color: 'black', transform: 'scale(.6)'}
+  ]
+
+supplementary_glaze:
+  category: 'supplementary'
+  name: 'for disabled people'
+  elements: [
+    { type: 'square-rounded', color: 'black', transform: 'scale(1,.5)'}
+    { type: 'square-rounded', color: 'white', transform: 'scale(.95, .45)'}
+    { type: 'snowflake', color: 'black', transform: 'scale(.8)'}
+  ]
+
 supplementary_left_pointing:
   category: 'supplementary'
   name: 'left pointing'
@@ -110,6 +128,16 @@ supplementary_left_pointing:
     { type: 'square-rounded', color: 'black', transform: 'scale(1,.5)'}
     { type: 'square-rounded', color: 'white', transform: 'scale(.95, .45)'}
     { type: 'DE-arrow-up', color: 'black', transform: 'scale(.6) rotate(-90deg)'}
+  ]
+
+supplementary_both_directions:
+  category: 'supplementary'
+  name: 'both directions'
+  elements: [
+    { type: 'square-rounded', color: 'black', transform: 'scale(1,.5)'}
+    { type: 'square-rounded', color: 'white', transform: 'scale(.95, .45)'}
+    { type: 'DE-arrow-up', color: 'black', transform: 'translate(-15%,0) scale(.5) rotate(180deg)'}
+    { type: 'DE-arrow-up', color: 'black', transform: 'translate(15%,0) scale(.5)'}
   ]
 
 supplementary_pedestrians_use_opposite_sidewalk:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,13 +9,13 @@ gulp.task('clean', shell.task(['rm -f .fontcustom-manifest.json', 'rm -rf ./buil
 
 gulp.task('compile-font', ['clean'], shell.task('fontcustom compile'));
 
-gulp.task('cson-signs', function() {
+gulp.task('cson-signs', ['clean'], function() {
   return gulp.src('dev/*.cson')
     .pipe(cson())
     .pipe(gulp.dest('build/json'));
 });
 
-gulp.task('cson-transformations', function() {
+gulp.task('cson-transformations', ['clean'], function() {
   return gulp.src('stylesheets/transformations.cson')
     .pipe(cson())
     .pipe(gulp.dest('build'))
@@ -27,16 +27,16 @@ gulp.task('concat-traffico-css', ['compile-font'], function() {
     .pipe(gulp.dest('build/stylesheets'))
 });
 
-gulp.task('gen-overview-css', function() {
+gulp.task('gen-overview-css', ['clean'], function() {
   return gulp.src('stylesheets/examples.scss').pipe(sass()).pipe(gulp.dest('build/stylesheets'));
 });
 
-gulp.task('gen-overview-scss', function() {
+gulp.task('gen-overview-scss', ['clean'], function() {
   return gulp.src('stylesheets/examples.scss').pipe(gulp.dest('build/gh-pages'));
 });
 
 gulp.task('gen-overview', ['cson-signs', 'cson-transformations'], function () {
-  return gulp.src('scripts/generate-overview.js').pipe(shell(['node <%= file.path %>']));
+  return gulp.src('scripts/generate-overview.js').pipe(shell(['mkdir -p build/gh-pages && node <%= file.path %>']));
 });
 
 gulp.task('default', ['concat-traffico-css', 'gen-overview', 'gen-overview-scss', 'gen-overview-css']);

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "gulp": "^3.8.10",
     "gulp-concat": "^2.4.3",
     "gulp-shell": "^0.2.11",
-    "gulp-cson": "0.0.1",
+    "gulp-cson": "0.2.0",
     "gulp-watch": "^4.0.2",
-    "gulp-sass": "1.3.2",
+    "gulp-sass": "1.3.3",
     "fs": "0.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "gulp": "^3.8.10",
     "gulp-concat": "^2.4.3",
     "gulp-shell": "^0.2.11",
-    "gulp-cson": "0.2.0",
+    "gulp-cson": "0.2.1",
     "gulp-watch": "^4.0.2",
     "gulp-sass": "1.3.3",
     "fs": "0.0.2"

--- a/scripts/check_build
+++ b/scripts/check_build
@@ -1,0 +1,18 @@
+#!/bin/bash
+# For usage with Travis CI
+numJson=$(ls -1 build/json/ | grep .json$ | wc -l)
+numCson=$(ls -1 dev/ | grep .cson$ | wc -l)
+
+if [ $numJson -ne $numCson ]
+then
+  echo "Not all *.json files were generated."
+  exit 1
+fi
+
+if [ ! -f build/gh-pages/examples.html ] || [ ! -f build/gh-pages/examples.scss ]
+then
+  echo "The example page for gh-pages has not been generated."
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
- Three supplementary signs were added: `supplementary_disabled`, `supplementary_glaze` and `supplementary_both_directions`

![supplementary](https://cloud.githubusercontent.com/assets/3904348/6373411/c6f6e2b6-bd0a-11e4-8d3c-c2b0f3b33ebf.png)
- Travis CI now builds the master-branch and does some simple checks (does the number of json-files equal the number of cson files? was examples.html generated?), implements the first part of #33. See [the corresponding build for this pull request in Travis CI](https://travis-ci.org/floscher/traffico/builds/52144852)
- Updated the npm-packages `gulp-cson` (see stevelacy/gulp-cson#2 for the reason for updating) and `gulp-sass` to the lastest version
- Fixed another problem with `gulpfile.js` that sometimes led to errors when running `gulp`. This is the new dependency-structure:

![gulp-dependencies](https://cloud.githubusercontent.com/assets/3904348/6373534/a22dd736-bd0b-11e4-994c-4925970e5478.png)
