### PR TITLE
Add speed limit sign. (Fixes #38)

### DIFF
--- a/dev/us.cson
+++ b/dev/us.cson
@@ -733,5 +733,26 @@ regulatory_speed_limit:
     { type: 'square-rounded', color: 'white', transform: 'scale(.7,1) scale(.90)' }
     { type: 'content-4', color: 'black',  content: 'SPEED', transform: 'translate(0,-145%) scale(.8)' }
     { type: 'content-4', color: 'black',  content: 'LIMIT', transform: 'translate(0,-60%) scale(.8)' }
-    { type: 'us_speed_value', color: 'black',  transform: 'translate(0,50%)' }
+    { type: 'us_speed_value', color: 'black',  transform: 'translate(0,45%)' }
+  ]
+
+regulatory_night_speed_limit:
+  category: 'regulatory'
+  name: 'night_speed_limit'
+  elements: [
+    { type: 'square-rounded', color: 'white' }
+    { type: 'square-rounded', color: 'black', transform: 'scale(.95)' }
+    { type: 'content-4', color: 'white',  content: 'NIGHT', transform: 'translate(0,-100%) scale(.8)' }
+    { type: 'us_speed_value', color: 'white',  transform: 'translate(0,35%) scale(1.1)' }
+  ]
+
+regulatory_truck_speed_limit:
+  category: 'regulatory'
+  name: 'truck_speed_limit'
+  elements: [
+    { type: 'square-rounded', color: 'white' }
+    { type: 'square-rounded', color: 'black', transform: 'scale(.95)' }
+    { type: 'square-rounded', color: 'white', transform: 'scale(.90)' }
+    { type: 'content-4', color: 'black',  content: 'TRUCKS', transform: 'translate(0,-100%) scale(.7,.9)' }
+    { type: 'us_speed_value', color: 'black',  transform: 'translate(0,35%) scale(1.1)' }
   ]

--- a/dev/us.cson
+++ b/dev/us.cson
@@ -723,3 +723,14 @@ warning_pretzel_loop:
     { type: 'square-rounded', color: 'yellow', transform: 'scale(.95) {square_to_diamond}' }
     { type: 'pretzel-loop', color: 'black', transform: '{fit_diamond}' }
   ]
+
+regulatory_speed_limit:
+  category: 'regulatory'
+  name: 'speed_limit'
+  elements: [
+    { type: 'square-rounded', color: 'black', transform: 'scale(.7,1)' }
+    { type: 'square-rounded', color: 'white', transform: 'scale(.7,1) scale(.95)' }
+    { type: 'content-4', color: 'black',  content: 'SPEED', transform: 'translate(0,-145%) scale(.8)' }
+    { type: 'content-4', color: 'black',  content: 'LIMIT', transform: 'translate(0,-60%) scale(.8)' }
+    { type: 'content-4', color: 'black',  content: '65', transform: 'translate(0,160%) scale(2.2)' }
+  ]

--- a/dev/us.cson
+++ b/dev/us.cson
@@ -728,9 +728,10 @@ regulatory_speed_limit:
   category: 'regulatory'
   name: 'speed_limit'
   elements: [
-    { type: 'square-rounded', color: 'black', transform: 'scale(.7,1)' }
-    { type: 'square-rounded', color: 'white', transform: 'scale(.7,1) scale(.95)' }
+    { type: 'square-rounded', color: 'white', transform: 'scale(.7,1)' }
+    { type: 'square-rounded', color: 'black', transform: 'scale(.7,1) scale(.95)' }
+    { type: 'square-rounded', color: 'white', transform: 'scale(.7,1) scale(.90)' }
     { type: 'content-4', color: 'black',  content: 'SPEED', transform: 'translate(0,-145%) scale(.8)' }
     { type: 'content-4', color: 'black',  content: 'LIMIT', transform: 'translate(0,-60%) scale(.8)' }
-    { type: 'content-4', color: 'black',  content: '65', transform: 'translate(0,160%) scale(2.2)' }
+    { type: 'us_speed_value', color: 'black',  transform: 'translate(0,50%)' }
   ]

--- a/scripts/generate-overview.js
+++ b/scripts/generate-overview.js
@@ -4,6 +4,7 @@ var fs = require('fs');
 const JSON_DIR = './build/json/';
 const VAR_VALUES = {
   speed_value: [10, 20, 25, 30, 35, 50, 60, 70, 75, 80, 90, 100, 110, 120, 130],
+  us_speed_value: [10, 25, 30, 35, 45, 50, 55, 60, 65, 70, 75, 80, 85],
   speed_zone_value: [20,30,40],
   height_value: ['2m ', '3.5m', '10ft'],
   incline_value: ['10%','12%'],


### PR DESCRIPTION
Uses the text syntax as in #42.

Based on other signs, it looks like there should be only one sign despite having different potential numbers. I chose to display 65.
