### PR TITLE
Fixed link to Travis build status

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,31 @@ install:
   - rvmsudo gem install fontcustom
   - npm install
 script:
-  - gulp
+  - npm run gulp
   - scripts/check_build
+
+# Automatically deploys a tagged release to GitHub pages if the Travis build succeeds
+after_success: |
+  if [ "$TRAVIS_TAG" == "" ]; then
+    echo "Not a tagged release, so GitHub pages are not updated!"
+  else
+    git config --global user.email "deploy@travis"
+    git config --global user.name "Travis CI"
+    git remote add deploy "https://knikel:${GH_TOKEN}@github.com/mapillary/traffico.git"
+    git fetch --depth=1 origin gh-pages:gh-pages
+    git checkout gh-pages
+    git rm examples.html _sass/pages/_examples.scss
+    cp build/gh-pages/examples.html ./
+    cp build/gh-pages/_config.yml ./
+    cp -T build/gh-pages/examples.scss _sass/pages/_examples.scss
+    git stage examples.html _config.yml _sass/pages/_examples.scss
+    masterCommit=`git rev-parse "$TRAVIS_TAG"`
+    git commit -m "Bump gh-pages to latest version
+
+  This commit has automatically been crafted by Travis CI based on $masterCommit."
+    git push deploy gh-pages
+  fi
+
+env:
+  global:
+    secure: h8M2G/BoR5uTTBhq1Y5Sfcs42FTM6ytzGDOkAMFj8GKxDQvP3DqYcDt6n7l2AhQb3jKFu1z1Qrk+g+oNpTo02Xu560wzMhg60/1yn1SFrCRkTl6f/YAfhQMIR6VEd++cYgG0ISkrm3O0QRDpByTxAOZa6LIzLcPAGr9LsiH+/fo=

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# traffico [![Build Status](https://travis-ci.org/mapillary/traffico.svg?branch=master)](https://travis-ci.org/floscher/traffico)
+# traffico [![Build Status](https://travis-ci.org/mapillary/traffico.svg?branch=master)](https://travis-ci.org/mapillary/traffico)
 An Open Source Traffic Sign Font. Read more on [traffico.io](http://traffico.io/)
 
 ## Getting the dependencies

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -39,7 +39,11 @@ gulp.task('gen-overview', ['cson-signs', 'cson-transformations'], function () {
   return gulp.src('scripts/generate-overview.js').pipe(shell(['mkdir -p build/gh-pages && node <%= file.path %>']));
 });
 
+gulp.task('generate_gh-pages_config', function () {
+  return gulp.src('scripts/generate_gh-pages_config.js').pipe(shell(['mkdir -p build/gh-pages && node <%= file.path %>']));
+});
+
 gulp.task('patch-names', ['gen-overview'], function() {
   return gulp.src('scripts/patch-names.js').pipe(shell(['node <%= file.path %>']));
 });
-gulp.task('default', ['concat-traffico-css', 'gen-overview', 'gen-overview-scss', 'gen-overview-css']);
+gulp.task('default', ['concat-traffico-css', 'gen-overview', 'gen-overview-scss', 'gen-overview-css', 'generate_gh-pages_config']);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "traffico",
-  "version": "0.1.4",
+  "version": "0.1.8",
   "description": "Traffic signs packaged in a font",
   "main": "gulpfile.js",
   "repository": {

--- a/scripts/generate_gh-pages_config.js
+++ b/scripts/generate_gh-pages_config.js
@@ -1,0 +1,10 @@
+var fs = require('fs');
+var version = JSON.parse(fs.readFileSync('package.json', 'utf8')).version;
+fs.writeFile(
+  'build/gh-pages/_config.yml',
+  "name: Traffico\nversion: "+version+"\nhighlighter: pygments\n",
+  function(err) {
+    if (err) throw err;
+  }
+);
+console.log("Generated configuration for GitHub pages (v"+version+")!");


### PR DESCRIPTION
This fixes the link to the current Travis build status, which currently points to the builds for my fork of the traffico-repo.

AFAICS everything is ready to building on Travis CI. The currently latest commit on master builds green in my fork (see [Travis CI log](https://travis-ci.org/floscher/traffico/builds/56749831)).

@knikel, you probably only have to flip the switch at https://travis-ci.org/profile/mapillary to kick off a build everytime someone pushes to this repo. Maybe you can also switch on "Build only if .travis.yml is present" at https://travis-ci.org/mapillary/traffico/settings to prevent the gh-pages branch from building.

But nevertheless there is still some work to do to tap the full potential of Travis. E.g. the built files could be automatically transferred to gh-pages, …. See #33 for more discussion.
