### PR TITLE
Update versions of npm-packages and setup-instructions for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ brew install node
 gem install fontcustom
 ```
 
-### Linux
+### Linux (Ubuntu 15.04)
 
 ```shell
-sudo apt-get install fontforge node
+sudo apt-get install fontforge nodejs nodejs-legacy npm ruby-dev zlib1g-dev
 wget http://people.mozilla.com/~jkew/woff/woff-code-latest.zip
 unzip woff-code-latest.zip -d sfnt2woff && cd sfnt2woff && make && sudo mv sfnt2woff /usr/local/bin/
 gem install fontcustom
@@ -30,7 +30,7 @@ The build process is a simple gulp task.
 
 First get the gulp dependencies: <code>npm install</code>.
 
-To finally build the font run: <code>gulp</code>.
+To finally build the font run: <code>npm run gulp</code>.
 
 The resulting `build`-folder contains the following:
 * `build/fonts/` contains the packaged font in different formats (woff, svg, eot, ttf)
@@ -39,7 +39,7 @@ The resulting `build`-folder contains the following:
 * `build/sign-overview.html` an overview of all the pre-built signs from the `json`-folder
 * `build/stylesheets/traffico.css` this file lets you simply use CSS-classes for constructing signs (see section "Usage")
 
-To remove all the generated files run <code>gulp clean</code>.
+To remove all the generated files run <code>npm run clean</code>.
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -14,12 +14,15 @@
   },
   "homepage": "https://github.com/mapillary/traffico",
   "devDependencies": {
-    "gulp": "^3.8.10",
-    "gulp-concat": "^2.4.3",
-    "gulp-shell": "^0.2.11",
-    "gulp-cson": "0.2.1",
-    "gulp-watch": "^4.0.2",
-    "gulp-sass": "1.3.3",
-    "fs": "0.0.2"
+    "gulp": "^3.9.0",
+    "gulp-concat": "^2.6.0",
+    "gulp-shell": "^0.4.2",
+    "gulp-cson": "0.3.0",
+    "gulp-watch": "^4.2.4",
+    "gulp-sass": "2.0.3"
+  },
+  "scripts": {
+    "gulp": "gulp",
+    "clean": "gulp clean"
   }
 }


### PR DESCRIPTION
I updated the installation instructions for Ubuntu linux, as the package containing Node is called `nodejs` in Ubuntu and some other packages are not preinstalled in Ubuntu.

Then I also added the two commands `npm run gulp` and `npm run clean`, which have the advantage that they run with exactly the version of gulp that is specified in the `package.json`-file. Regardless of what version of gulp you've installed on your machine, **if** you have it installed, as you don't have to anymore.

And last but not least, I bumped all npm-dependencies to their latest version, so everyone should do a `npm install` after this pull request is merged.
