### PR TITLE
Add JSON-template that maps glyph names to their Unicode codepoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To finally build the font run: <code>gulp</code>.
 The resulting `build`-folder contains the following:
 * `build/fonts/` contains the packaged font in different formats (woff, svg, eot, ttf)
 * `build/fonts/traffico-preview.html` a collection of all available symbols for building custom signs
-* `build/json` contains json-files with pre-built sign-definitions
+* `build/signs` contains json-files with pre-built sign-definitions
 * `build/sign-overview.html` an overview of all the pre-built signs from the `json`-folder
 * `build/stylesheets/traffico.css` this file lets you simply use CSS-classes for constructing signs (see section "Usage")
 

--- a/fontcustom.yml
+++ b/fontcustom.yml
@@ -47,13 +47,13 @@ no_hash: false
 
 input:
   vectors: icons
-  #templates: templates
+  templates: templates
 
 output:
   fonts: build/fonts
   css: build/stylesheets
   #preview: app/views/styleguide
- # my-custom-template.yml: path/to/template/output
+  glyphs.json: build/
 
 
 # -----------------------------------------------------------------------------
@@ -70,10 +70,10 @@ output:
 #   Default: css, preview
 # -----------------------------------------------------------------------------
 
-#templates:
-#- scss-rails
-#- preview
-#- my-custom-template.yml
+templates:
+- css
+- preview
+- glyphs.json
 
 #preprocessor_path: ../fonts/
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,7 +12,7 @@ gulp.task('compile-font', ['clean'], shell.task('fontcustom compile'));
 gulp.task('cson-signs', ['clean'], function() {
   return gulp.src('dev/*.cson')
     .pipe(cson())
-    .pipe(gulp.dest('build/json'));
+    .pipe(gulp.dest('build/signs'));
 });
 
 gulp.task('cson-transformations', ['clean'], function() {

--- a/scripts/check_build
+++ b/scripts/check_build
@@ -1,6 +1,6 @@
 #!/bin/bash
 # For usage with Travis CI
-numJson=$(ls -1 build/json/ | grep .json$ | wc -l)
+numJson=$(ls -1 build/signs/ | grep .json$ | wc -l)
 numCson=$(ls -1 dev/ | grep .cson$ | wc -l)
 
 if [ $numJson -ne $numCson ]

--- a/scripts/generate-overview.js
+++ b/scripts/generate-overview.js
@@ -1,7 +1,7 @@
 var fs = require('fs');
 
 /** Config */
-const JSON_DIR = './build/json/';
+const JSON_DIR = './build/signs/';
 const VAR_VALUES = {
   speed_value: [10, 20, 25, 30, 35, 50, 60, 70, 75, 80, 90, 100, 110, 120, 130],
   speed_zone_value: [20,30,40],

--- a/templates/glyphs.json
+++ b/templates/glyphs.json
@@ -1,0 +1,6 @@
+{
+  "name": "<%= font_name %>",
+  "glyphs": {<% @glyphs.each_with_index do |(name, value), index| %><%= "," if index >= 1 %>
+    "<%= name.to_s %>":"\u<%= value[:codepoint].to_s(16) %>"<% end %>
+  }
+}


### PR DESCRIPTION
This is useful when you don't use CSS for displaying signs, as you can simply read the codepoints from a JSON-file (in my case I had the JOSM-plugin in mind, but might also be useful for others).

The generated file looks like this:

```
{
  "name": "traffico",
  "glyphs": {
    "DE-arrow-up":"\uf100",
    "US-arrow-oneway":"\uf101",
    …
  }
}
```

As there are now quite a few JSON-resources generated when running gulp, I also renamed the build-folder for the JSON-files describing the traffic signs per country from `build/json` to `build/signs`.
