### PR TITLE
Allow signs with multiple variable values

### DIFF
--- a/scripts/generate-overview.js
+++ b/scripts/generate-overview.js
@@ -120,7 +120,7 @@ var builtFiles = fs.readdir(JSON_DIR, function(err, files) {
           for (var i in VAR_VALUES[typeOfVariableContent]) {
             var value = VAR_VALUES[typeOfVariableContent][i] + "";
             var length = value.length;
-            var currentT = currentSign.replace(/\{\{\{variable\}\}\}/, value).replace(/\{\{\{length\}\}\}/, length == 2 ? '' : '-' + length);
+            var currentT = currentSign.replace(/\{\{\{variable\}\}\}/g, value).replace(/\{\{\{length\}\}\}/g, length == 2 ? '' : '-' + length);
             currentSignContainer += currentT;
 
             // Add appropriate keys with speed values as object properties


### PR DESCRIPTION
Previously only the first occurence of a variable value in a sign has been replaced. Now every occurence is being replaced.

Example:

``` cson
category_sign_name:
  category: 'category'
  name: 'sign_name'
  elements: [
    { type: 'speed_value', color: 'red' }
    { type: 'speed_value', color: 'blue', transform: 'rotate(5deg)' }
  ]
```

This would've resulted in a series of signs with variable speed-values in red and the string `{{{variable}}}` in blue. Now both the red and the blue text contain the variable speed-values.
