### PR TITLE
Move the baseline of the font to the center

### DIFF
--- a/fontcustom.yml
+++ b/fontcustom.yml
@@ -88,9 +88,9 @@ templates:
 # The em size. Setting this will scale the entire font to the given size.
 #font_em: 512
 
-# The font's descent and descent. Used to calculate the baseline.
-#font_ascent: 448
-#font_descent: 64
+# The font's ascent and descent. Used to calculate the baseline.
+font_ascent: 256
+font_descent: 256
 
 # Horizontally fit glyphs to their individual vector widths.
 #autowidth: true


### PR DESCRIPTION
Now both the ascent and the descent of the font is 256, which means the [baseline](https://en.wikipedia.org/wiki/Baseline_%28typography%29) is vertically centered in all glyphs.
This helps with positioning the glyphs in situations where the baseline matters (e.g. when [drawing glyphs with Graphics2D in Java](http://docs.oracle.com/javase/8/docs/api/java/awt/Graphics2D.html#drawString-java.lang.String-int-int-)).

I decided against a baseline at the bottom of the character (ascent 512, descent 0) because not all glyphs are filling the complete available vertical space but they are normally aligned to the center of the glyph.
