### PR TITLE
Add watch task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,6 +4,7 @@ var concat = require('gulp-concat')
 var cson = require('gulp-cson')
 var es = require('event-stream')
 var sass = require('gulp-sass')
+var watch = require('gulp-watch')
 var zip = require('gulp-zip')
 
 gulp.task('clean', shell.task(['rm -f .fontcustom-manifest.json', 'rm -rf ./build/']))
@@ -117,3 +118,9 @@ gulp.task(
   'default',
   ['check']
 )
+
+gulp.task('watch', function (cb) {
+  watch(['dev/*', 'icons/*'], function (events, done) {
+    gulp.start('check')
+  })
+})

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "check": "gulp check",
     "clean": "gulp clean",
     "lint": "gulp lint",
-    "pngs": "gulp pngs"
+    "pngs": "gulp pngs",
+    "watch": "gulp watch"
   }
 }


### PR DESCRIPTION
> Night gathers, and now my watch begins. Winter is coming… :wink:

Once upon a time there was a watch-task in this repo, but at some point it disappeared.
This is a new one, not perfect but already functional. Just run `npm run watch` and as soon as you change one of the files in `icons/` or `dev/`, the `check`-task will run.
One drawback of this approach is, that the whole watch-task stops, when the `check`-task fails.
